### PR TITLE
FXTrayIcon constructor with Image arg and setGraphic overload

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -554,8 +554,16 @@ public class FXTrayIcon {
      */
     @API
     public void setGraphic(javafx.scene.image.Image img) {
-        BufferedImage bufferedImage = SwingFXUtils.fromFXImage(img, null);
-        this.trayIcon.setImage(bufferedImage);
+        setGraphic(SwingFXUtils.fromFXImage(img, null));
+    }
+
+    /**
+     * Provides a way to change the TrayIcon image at runtime.
+     * @param img Java AWT Image
+     */
+    @API
+    public void setGraphic(Image img) {
+        this.trayIcon.setImage(img);
     }
 
     /**


### PR DESCRIPTION
Hello Dustin,

Thank you very much for this compact and useful `FXTrayIcon` project!

I'm going to use your lib in my project and would like to suggest a minor adjustment for the API of the `FXTrayIcon` object.

### Use Case

The use case is the following: there are several images pre-loaded from local files and stored in an object. These images will be used as tray icons set in runtime, depending on the state of my application.

### Current Implementation

The current implementation of `FXTrayIcon` allows to instantiate it only with image file paths typed as `URL`.

Changing the icon in runtime is possible with `javafx.scene.image.Image` type only, but the target type is the good old `java.awt.Image`.

### Suggested Changes

Add a constructor which takes `java.awt.Image` as an argument with pre-loaded image data. The two existing constructors with `URL`s can be chained to it.

Add an overload for the `setGraphic` method, which takes a `java.awt.Image` as its arg. The existing `setGraphic` is chained to this overload, because it was transforming a FX image instance into an AWT image.

Other changes: flattened the constructor logic by extracting the methods `ensureSystemTraySupported()`, `attemptSetSystemLookAndFeel()` and `loadImageFromFile()`, making the constructor shorter and simpler.
