### PR TITLE
Added method addMenuItems 

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -335,7 +335,8 @@ public class FXTrayIcon {
      * @param index Index to insert the MenuItem at
      */
     @API
-    public void insertMenuItem(javafx.scene.control.MenuItem menuItem, int index) {
+    public void insertMenuItem(javafx.scene.control.MenuItem menuItem,
+                               int index) {
         EventQueue.invokeLater(() -> {
             if (isNotUnique(menuItem)) {
                 throw new UnsupportedOperationException(

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -47,6 +47,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -306,29 +307,24 @@ public class FXTrayIcon {
     }
 
     /**
-     * Adds the specified MenuItems to the FXTrayIcon's menu
-     * Add separators by creating a MenuItem with text 'separator'
-     * ex: addMenuItems(menuItem1, menuItem2, menuSeparator, menuItem3);
-     * @param menuItems multiple MenuItem objects to be added
+     * Adds the specified MenuItems to FXTrayIcon's menu.
+     * Pass in as many MenuItems as needed separated by a comma.
+     * ex: addMenuItems(menuItem1, menuItem2, menuItem3);
+     * @param menuItems multiple comma separated MenuItem objects
      */
     @API
     public void addMenuItems(javafx.scene.control.MenuItem... menuItems ) {
         EventQueue.invokeLater(() -> {
             for (javafx.scene.control.MenuItem menuItem : menuItems) {
-                if (menuItem.getText().equals("separator")) {
-                    this.popupMenu.addSeparator();
+                if (menuItem instanceof Menu) {
+                    addMenu((Menu) menuItem);
+                    return;
                 }
-                else {
-                    if (menuItem instanceof Menu) {
-                        addMenu((Menu) menuItem);
-                        return;
-                    }
-                    if (isNotUnique(menuItem)) {
-                        throw new UnsupportedOperationException(
-                                "Menu Item labels must be unique, duplicate menuItem: " + menuItem.getText());
-                    }
-                    this.popupMenu.add(AWTUtils.convertFromJavaFX(menuItem));
+                if (isNotUnique(menuItem)) {
+                    throw new UnsupportedOperationException(
+                            "Menu Item labels must be unique.");
                 }
+                this.popupMenu.add(AWTUtils.convertFromJavaFX(menuItem));
             }
         });
     }
@@ -340,8 +336,7 @@ public class FXTrayIcon {
      * @param index Index to insert the MenuItem at
      */
     @API
-    public void insertMenuItem(javafx.scene.control.MenuItem menuItem,
-                               int index) {
+    public void insertMenuItem(javafx.scene.control.MenuItem menuItem, int index) {
         EventQueue.invokeLater(() -> {
             if (isNotUnique(menuItem)) {
                 throw new UnsupportedOperationException(
@@ -578,6 +573,18 @@ public class FXTrayIcon {
     public void setGraphic(javafx.scene.image.Image img) {
         BufferedImage bufferedImage = SwingFXUtils.fromFXImage(img, null);
         this.trayIcon.setImage(bufferedImage);
+    }
+
+    /**
+     * Provides a way to change the TrayIcon image at runtime.
+     * @param imgFile java.io.File Object
+     */
+    @API
+    public void setGraphic(File imgFile) {
+        try {
+            this.trayIcon.setImage(ImageIO.read(imgFile));
+        }
+        catch (IOException e) {e.printStackTrace();}
     }
 
     /**

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -306,6 +306,34 @@ public class FXTrayIcon {
     }
 
     /**
+     * Adds the specified MenuItems to the FXTrayIcon's menu
+     * Add separators by creating a MenuItem with text 'separator'
+     * ex: addMenuItems(menuItem1, menuItem2, menuSeparator, menuItem3);
+     * @param menuItems multiple MenuItem objects to be added
+     */
+    @API
+    public void addMenuItems(javafx.scene.control.MenuItem... menuItems ) {
+        EventQueue.invokeLater(() -> {
+            for (javafx.scene.control.MenuItem menuItem : menuItems) {
+                if (menuItem.getText().equals("separator")) {
+                    this.popupMenu.addSeparator();
+                }
+                else {
+                    if (menuItem instanceof Menu) {
+                        addMenu((Menu) menuItem);
+                        return;
+                    }
+                    if (isNotUnique(menuItem)) {
+                        throw new UnsupportedOperationException(
+                                "Menu Item labels must be unique, duplicate menuItem: " + menuItem.getText());
+                    }
+                    this.popupMenu.add(AWTUtils.convertFromJavaFX(menuItem));
+                }
+            }
+        });
+    }
+
+    /**
      * Inserts the specified MenuItem into the FXTrayIcon's menu
      * at the supplied index.
      * @param menuItem MenuItem to be inserted

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -47,7 +47,6 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -573,18 +572,6 @@ public class FXTrayIcon {
     public void setGraphic(javafx.scene.image.Image img) {
         BufferedImage bufferedImage = SwingFXUtils.fromFXImage(img, null);
         this.trayIcon.setImage(bufferedImage);
-    }
-
-    /**
-     * Provides a way to change the TrayIcon image at runtime.
-     * @param imgFile java.io.File Object
-     */
-    @API
-    public void setGraphic(File imgFile) {
-        try {
-            this.trayIcon.setImage(ImageIO.read(imgFile));
-        }
-        catch (IOException e) {e.printStackTrace();}
     }
 
     /**

--- a/src/test/java/com/dustinredmond/fxtrayicon/MultipleItemsOneLine.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/MultipleItemsOneLine.java
@@ -13,12 +13,11 @@ public class MultipleItemsOneLine extends Application {
 		icon.show();
 		MenuItem menu1     = new MenuItem("Option 1");
 		MenuItem menu2     = new MenuItem("Option 2");
-		MenuItem separator = new MenuItem("separator");
 		MenuItem exitMenu  = new MenuItem("Exit");
 		menu1.setOnAction(e -> menu1());
 		menu2.setOnAction(e -> menu2());
 		exitMenu.setOnAction(e -> System.exit(0));
-		icon.addMenuItems(menu1, menu2, separator, exitMenu);
+		icon.addMenuItems(menu1, menu2, exitMenu);
 	}
 
 	private void menu1() {System.out.println("Option 1");}

--- a/src/test/java/com/dustinredmond/fxtrayicon/MultipleItemsOneLine.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/MultipleItemsOneLine.java
@@ -1,0 +1,30 @@
+package com.dustinredmond.fxtrayicon;
+
+import javafx.application.Application;
+import javafx.scene.control.MenuItem;
+import javafx.stage.Stage;
+
+public class MultipleItemsOneLine extends Application {
+
+	@Override
+	public void start(Stage primaryStage) {
+		primaryStage.setTitle("Many From One");
+		FXTrayIcon icon = new FXTrayIcon(primaryStage, getClass().getResource("icons8-link-64.png"));
+		icon.show();
+		MenuItem menu1     = new MenuItem("Option 1");
+		MenuItem menu2     = new MenuItem("Option 2");
+		MenuItem separator = new MenuItem("separator");
+		MenuItem exitMenu  = new MenuItem("Exit");
+		menu1.setOnAction(e -> menu1());
+		menu2.setOnAction(e -> menu2());
+		exitMenu.setOnAction(e -> System.exit(0));
+		icon.addMenuItems(menu1, menu2, separator, exitMenu);
+	}
+
+	private void menu1() {System.out.println("Option 1");}
+	private void menu2() {System.out.println("Option 2");}
+
+	public static void main(String[] args) {
+		launch(args);
+	}
+}


### PR DESCRIPTION
I added a method named addMenuItems, which allows the developer to add an unlimited number of MenuItems in a single method call. Also, if they create a MenuItem with the text 'separator' attached to it, it will add a separator, which conveniently allows the creation of a somewhat complex menu with one line of code:

For example, this line of code

`icon.addMenuItems(menu1, menu2, separator, menu3, menu4, separator, exitMenu);`

Creates this menu

<img width="246" alt="Screen Shot 2021-09-08 at 4 54 20 AM" src="https://user-images.githubusercontent.com/10106834/132505293-dc294b7f-eeec-4a79-ba6d-3ba906e00c9e.png">


Also, the check for duplicate menuItems still works as well.

I also added a test Class called **MultipleItemsOneLine**