### PR TITLE
Update FXTrayIcon Builder trayIcon to protected

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -120,7 +120,7 @@ public class FXTrayIcon {
     @API
     public static class Builder {
 
-        private final FXTrayIcon trayIcon;
+        protected FXTrayIcon trayIcon;
         private boolean showMenu = false;
         private final String fileName1 = "FXIconRedWhite.png";
         URL icon1 = getClass().getResource(fileName1);


### PR DESCRIPTION
Changed trayIcon in FXTrayIcon.Builder to be protected. This allows extending the Builder and setting trayIcon to an extend instance of FXTrayIcon.