### PR TITLE
Updated setGraphic(File) method

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -47,6 +47,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -962,15 +963,45 @@ public class FXTrayIcon {
      */
     @API
     public void setGraphic(File file) {
-        javafx.scene.image.Image img;
-        try {
-            img = new javafx.scene.image.Image(file.getAbsolutePath());
-        }
-        catch(Exception e) {
-            img = new javafx.scene.image.Image("file:" + file.getAbsolutePath());
-        }
+        javafx.scene.image.Image img = new javafx.scene.image.Image(file.getAbsolutePath());
         setGraphic(SwingFXUtils.fromFXImage(img, null));
     }
+
+    /**
+     * Provides a way to change the TrayIcon image at runtime.
+     * @param file a java.io.Fil object
+     * @param iconWidth an int, the width of the icon
+     * @param iconHeight an int, the height of the icon
+     */
+    @API
+    public void setGraphic(File file, int iconWidth, int iconHeight) {
+        try {
+            Image image = loadImageFromFile(new URL("file:" + file.getAbsolutePath()),iconWidth, iconHeight);
+            setGraphic(image);
+        }
+        catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Provides a way to change the TrayIcon image at runtime.
+     * @param URLString a String of the URL to the image file
+     * @param iconWidth an int, the width of the icon
+     * @param iconHeight an int, the height of the icon
+     */
+    @API
+    public void setGraphic(String URLString, int iconWidth, int iconHeight) {
+        try {
+            Image image = loadImageFromFile(new URL(URLString),iconWidth, iconHeight);
+            setGraphic(image);
+        }
+        catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
 
     /**
      * Provides a way to change the TrayIcon image at runtime.

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -976,7 +976,8 @@ public class FXTrayIcon {
     @API
     public void setGraphic(File file, int iconWidth, int iconHeight) {
         try {
-            Image image = loadImageFromFile(new URL("file:" + file.getAbsolutePath()),iconWidth, iconHeight);
+            URL url = new URL("file:" + file.getAbsolutePath());
+            Image image = loadImageFromFile(url,iconWidth, iconHeight);
             setGraphic(image);
         }
         catch (MalformedURLException e) {
@@ -993,7 +994,8 @@ public class FXTrayIcon {
     @API
     public void setGraphic(String URLString, int iconWidth, int iconHeight) {
         try {
-            Image image = loadImageFromFile(new URL(URLString),iconWidth, iconHeight);
+            URL url = new URL(URLString);
+            Image image = loadImageFromFile(url,iconWidth, iconHeight);
             setGraphic(image);
         }
         catch (MalformedURLException e) {

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -962,7 +962,13 @@ public class FXTrayIcon {
      */
     @API
     public void setGraphic(File file) {
-        javafx.scene.image.Image img = new javafx.scene.image.Image(file.getAbsolutePath());
+        javafx.scene.image.Image img;
+        try {
+            img = new javafx.scene.image.Image(file.getAbsolutePath());
+        }
+        catch(Exception e) {
+            img = new javafx.scene.image.Image("file:" + file.getAbsolutePath());
+        }
         setGraphic(SwingFXUtils.fromFXImage(img, null));
     }
 

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -981,7 +981,7 @@ public class FXTrayIcon {
             setGraphic(image);
         }
         catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
     }
 
@@ -999,7 +999,7 @@ public class FXTrayIcon {
             setGraphic(image);
         }
         catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+            e.printStackTrace();
         }
     }
 


### PR DESCRIPTION
The updateGraphic(File file) method when used with Java 18, throws an exception, because when loading a JavaFX Image from a file path, it has to be preceded with the word "file:" - and I can't remember if that is also true of Java 1.8, but I tend to think it's not.

So I updated the method to catch the error if it's thrown, then it will prepend the path to the file with "file:" and then it loads the image and keeps moving along... 

Tested it in GistFX and it works properly.