### PR TITLE
Manifest entry added to POM file for Modular compatibility

### DIFF
--- a/BuilderTutorial.md
+++ b/BuilderTutorial.md
@@ -6,7 +6,7 @@ you can set any option, add menuItems and even subMenus to your tray icon, all i
 FXTrayIcon will build the menu in the order in which you add the items into your build sentence.
 
 Here are the constructor options for the Builder
-```
+```Java
 FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, URL iconImagePath)
 FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, java.io.File iconImageFile)
 FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, javafx.scene.image.Image iconJavaFXImage)

--- a/BuilderTutorial.md
+++ b/BuilderTutorial.md
@@ -1,0 +1,166 @@
+## FXTrayIcon Builder Class
+### This document outlines the various ways you can instantiate FXTrayIcon using its Builder class
+
+Perhaps the most convenient way to instantiate FXTray Icon is through the Builder class. With the Builder,
+you can set any option, add menuItems and even subMenus to your tray icon, all in one line of code, and
+FXTrayIcon will build the menu in the order in which you add the items into your build sentence.
+
+Here are the constructor options for the Builder
+```
+FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, URL iconImagePath)
+FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, java.io.File iconImageFile)
+FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, javafx.scene.image.Image iconJavaFXImage)
+FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, java.awt.Image iconJavaAWTImage)
+```
+
+OR any of the above options with the addition of the icon size. For example:
+```java
+FXTrayIcon trayIcon = new FXTrayIcon.Builder(primaryStage, URL iconImagePath, int width, int height)
+```
+After you state the constructor, you have these options available to build your tray icon:
+
+Add menuItems dynamically without needing to pre-build them, by passing in the label and the
+event that the menuItem will execute:
+```java
+new FXTrayIcon.Builder(stage,icon).menuItem("My Menu", e -> myMenuMethod()).build();
+```
+OR, you can pre-build them and add them into the Builder like this
+```java
+MenuItem myMenuItem = new MenuItem;
+myMenuItem.setOnAction(e-> myMenuMethod());
+new FXTrayIcon.Builder(stage,icon).menuItem(myMenuItem).build();
+```
+
+You can also include multiple menuItems in one statement like this
+
+```java
+new FXTrayIcon.Builder(stage,icon)
+    .menuItem("My Menu 1", e -> myMenuMethod1())
+    .menuItem("My Menu 2", e -> myMenuMethod2())
+    .build();
+```
+OR pre-built
+```java
+MenuItem myMenuItem1 = new MenuItem;
+myMenuItem1.setOnAction(e-> myMenuMethod1());
+
+MenuItem myMenuItem2 = new MenuItem;
+myMenuItem2.setOnAction(e-> myMenuMethod2());
+
+new FXTrayIcon.Builder(stage,icon).menuItems(myMenuItem1, myMenuItem2).build();
+```
+
+Or you can even pre-build an entire Menu with MenuItems, then add that in as a branched submenu:
+
+```java
+Menu menu = new Menu("My Sub Menu");
+
+MenuItem myMenuItem1 = new MenuItem;
+myMenuItem1.setOnAction(e-> myMenuMethod1());
+
+MenuItem myMenuItem2 = new MenuItem;
+myMenuItem2.setOnAction(e-> myMenuMethod2());
+
+menu.getItems().addAll(myMenuItem1, myMenuItem2);
+
+new FXTrayIcon.Builder(stage,icon).menu(menu).build();
+```
+
+You can also add a branched sub-menu dynamically by calling the menu Builder method, giving
+the sub-menu a label then passing in MenuItem objects like this
+
+```java
+MenuItem myMenuItem1 = new MenuItem;
+myMenuItem1.setOnAction(e-> myMenuMethod1());
+
+MenuItem myMenuItem2 = new MenuItem;
+myMenuItem2.setOnAction(e-> myMenuMethod2());
+
+new FXTrayIcon.Builder(stage,icon).menu("My Sub Menu", menuItem1, menuItem2).build();
+```
+
+Add menu separator lines like this and FXTray Icon will place the separators (and all
+objects you include), in the order that you have them in your build sentence.
+
+```java
+new FXTrayIcon.Builder(stage,icon)
+    .menuItem("My Menu 1", e -> myMenuMethod1())
+    .menuItem("My Menu 2", e -> myMenuMethod2())
+    .separator()
+    .menuItem("My Menu 3", e -> myMenuMethod3())
+    .separator()
+    .menuItem("My Menu 4", e -> myMenuMethod4())
+    .build();
+```
+
+Add a tooltip that will display when the mouse pointer is hovered over the trayIcon
+
+```java
+new FXTrayIcon.Builder(stage,icon)
+    .menuItem("My Menu 1", e -> myMenuMethod1())
+    .tooltip("This is your Tray Icon")
+    .build();
+```
+
+FXTray Icon has something called a TitleItem, that is simply a MenuItem with the label
+set to the Applications Title String, that will call the Stage that you passed into the
+main constructor and bring it into view. When you use this option, that menuItem will
+always be at the top of your menu list.
+```java
+new FXTrayIcon.Builder(stage,icon).addTitleItem(true).build();
+```
+
+Alternatively, you can do the same thing, but assign the actual AppTitle string with
+the call
+```java
+new FXTrayIcon.Builder(stage,icon).applicationTitle("My Application Title").build();
+```
+
+Next, we have the onAction option. This is an option that will run an event that you pass
+into the argument and will run differently depending on the operating system. Under Windows,
+a simple left click on the tray Icon will invoke the event. On a Mac, it will be necessary
+to click both the left and right mouse buttons at the same time.
+```java
+new FXTrayIcon.Builder(stage,icon).onAction(e -> myMethod()).build();
+```
+
+Then we have the Exit menu item. This is a special MenuItem that will ALWAYS be placed
+at the bottom of the menu list, even if you add or remove items from the list during
+runtime. Invoking the menuItem will close the application. There are three ways to use
+this option:
+
+With the default label
+```java
+new FXTrayIcon.Builder(stage,icon).addExitMenuItem().build();
+```
+
+With a label of your choosing
+```java
+new FXTrayIcon.Builder(stage,icon).addExitMenuItem("My Exit Menu Label").build();
+```
+
+Or by passing in your own event that will close your app however you decide it needs to
+be closed
+```java
+new FXTrayIcon.Builder(stage,icon).addExitMenuItem("My Exit Label", e -> myExitMethod()).build();
+```
+
+Last, we have the show() option, which will simply cause FXTrayIcon to show the icon
+immediately after it's built so that you don't have to add call the show method after you
+create your build sentence.
+
+So for example, this Builder call will build the trayIcon, and show it all at the same time
+```java
+new FXTrayIcon.Builder(stage,icon)
+    .menuItem("My Menu 1", e -> myMenuMethod1())
+    .menuItem("My Menu 2", e -> myMenuMethod2())
+    .separator()
+    .menuItem("My Menu 3", e -> myMenuMethod3())
+    .separator()
+    .menuItem("My Menu 4", e -> myMenuMethod4())
+    .addExitMenuItem()
+    .show()
+    .build();
+```
+
+Have Fun!

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ supports the system tray.
 
 
 ## Projects using `FXTrayIcon`
-- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
-- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
--  [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
+- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates
+- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX
+- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ supports the system tray.
 
 
 ## Projects using `FXTrayIcon`
-- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates
-- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX
-- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient
+- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
+- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
+- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ icon.show();
 ```java
 FXTrayIcon icon = new FXTrayIcon.Builder(stage, iconURL).menuItem("Menu 1", e-> myMethod()).addExitItem().show().build();
 ```
-[Click here for a Builder tutorial](https://github.com/EasyG0ing1/FXTrayIcon/blob/main/BuilderTutorial.md)
+[Click here for a Builder tutorial](https://github.com/dustinkredmond/FXTrayIcon/blob/main/BuilderTutorial.md)
 
 ## How do I add to my project 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ icon.show();
 ```java
 FXTrayIcon icon = new FXTrayIcon.Builder(stage, iconURL).menuItem("Menu 1", e-> myMethod()).addExitItem().show().build();
 ```
-[Click here for a Builder tutorial](https://github.com/dustinkredmond/FXTrayIcon/blob/main/BuilderTutorial.md)
+[Click here for a Builder tutorial](https://github.com/EasyG0ing1/FXTrayIcon/blob/main/BuilderTutorial.md)
 
 ## How do I add to my project 
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ supports the system tray.
 
 
 ## Projects using `FXTrayIcon`
-* [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
-* [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
-* [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
+- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
+- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
+- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,6 @@ supports the system tray.
 ## Projects using `FXTrayIcon`
 - [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
 - [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
-- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
+-  [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ supports the system tray.
 
 
 ## Projects using `FXTrayIcon`
-- [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
-- [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
-- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing your GitHub Gists easy, convenient and fun.
+* [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
+* [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
+* [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ icon.show();
 ```java
 FXTrayIcon icon = new FXTrayIcon.Builder(stage, iconURL).menuItem("Menu 1", e-> myMethod()).addExitItem().show().build();
 ```
+[Click here for a Builder tutorial](https://github.com/dustinkredmond/FXTrayIcon/blob/main/BuilderTutorial.md)
 
 ## How do I add to my project 
 
@@ -121,5 +122,6 @@ supports the system tray.
 ## Projects using `FXTrayIcon`
 - [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
 - [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
+- [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing your GitHub Gists easy, convenient and fun.
 
 If your project uses FXTrayIcon, let us know via Pull Request, and we'll feature your project on this README.

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -92,31 +92,17 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
-            </plugin>
-            <!-- Maven jar plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
-                <configuration>
-                    <skipIfEmpty>true</skipIfEmpty>
-                    <archive>
-                        <manifestEntries>
-                            <Automatic-Module-Name>com.dustinkredmond.fxtrayicon</Automatic-Module-Name>
-                        </manifestEntries>
-                    </archive>
                 </configuration>
             </plugin>
             <!-- Maven Deploy plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
+                <version>3.0.0-M2</version>
                 <executions>
                     <execution>
                         <id>default-deploy</id>
@@ -132,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <localCheckout>true</localCheckout>
                     <pushChanges>false</pushChanges>
@@ -143,7 +129,7 @@
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.5</version>
+                        <version>2.0.0-M1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -152,7 +138,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
+                <version>1.6.13</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -165,13 +151,20 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>com.dustinkredmond.fxtrayicon</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -180,7 +173,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.4.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
@@ -198,7 +191,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.6</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>sign-artifact</id>
@@ -212,7 +205,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.0.0-M6</version>
                 <configuration>
                     <excludes>
                         <exclude>**/*.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,20 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
-
+            <!-- Maven jar plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.dustinkredmond.fxtrayicon</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <!-- Maven Deploy plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
When building a modular project, there is a file that is central to the project that manages the inclusion and scope of dependencies in the project. There is a mandate that requires module names to follow the domain naming schema, so when developers use a library that cannot be identified by a proper name, it becomes difficult to use the library.

Adding ```Automatic-Module-Name``` to the manifest file solves this problem, by giving the library a proper name that can be used in a ```module-info.java``` file within a modular project.

I added the manifest entry to the ```maven-source-plugin```.

I also updated all of the plugin versions in the POM file.

And I wasn't quite sure why you have this line under your ```maven-release-plugin``` 
```
<arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
```
In my IDE it throws an error ... this is how I usually have my release plugin configured and then when I deploy, I get prompted for my gpg password, which has a long timeout set so that if I have to deploy again (because of some problem), I don't get prompted again.

```
<plugin>
    <groupId>org.apache.maven.plugins</groupId>
    <artifactId>maven-release-plugin</artifactId>
    <version>3.0.0-M5</version>
    <configuration>
        <localCheckout>true</localCheckout>
        <pushChanges>false</pushChanges>
        <mavenExecutorId>forked-path</mavenExecutorId>
    </configuration>
    <dependencies>
        <dependency>
            <groupId>org.apache.maven.scm</groupId>
            <artifactId>maven-scm-provider-gitexe</artifactId>
            <version>2.0.0-M1</version>
        </dependency>
    </dependencies>
</plugin>
```