### PR TITLE
JPMS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
-dist: trusty
+dist: bionic
 install: true
 jdk:
-  - oraclejdk8
+  - openjdk11
 branches:
   only:
   - main

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,18 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-swing</artifactId>
+            <version>19</version>
+        </dependency>
+
     </dependencies>
 
     <profiles>
@@ -94,8 +106,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <!-- Maven Deploy plugin -->

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+/**
+ * FXTrayIcon java 9+ JPMS compatible
+ */
+module com.dustinredmond.fxtrayicon{
+    requires javafx.controls;
+    requires java.desktop;
+    requires javafx.swing;
+
+    exports com.dustinredmond.fxtrayicon;
+}

--- a/src/test/java/com/dustinredmond/fxtrayicon/notaskbaricon/Main.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/notaskbaricon/Main.java
@@ -24,7 +24,6 @@ package com.dustinredmond.fxtrayicon.notaskbaricon;
 
 import com.dustinredmond.fxtrayicon.FXTrayIcon;
 import com.dustinredmond.fxtrayicon.RunnableTest;
-import com.sun.javafx.application.PlatformImpl;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -74,8 +73,11 @@ public class Main extends Application {
 		mainStage.initStyle(StageStyle.UTILITY); //This is what makes the icon disappear in Windows.
 		if (FXTrayIcon.isSupported()) {
 			icon = new FXTrayIcon.Builder(stage, iconFile)
-					.menuItem("Show Stage",e -> {Platform.runLater(()-> PlatformImpl.setTaskbarApplication(false));mainStage.show();})
-					.menuItem("Hide Stage",e -> {Platform.runLater(() -> PlatformImpl.setTaskbarApplication(true));mainStage.hide();})
+					.menuItem("Show Stage",e -> {
+						Platform.runLater(()-> stage.setIconified(false));
+						mainStage.show();})
+					.menuItem("Hide Stage",e -> {Platform.runLater(() -> stage.setIconified(true) );
+						mainStage.hide();})
 					.menuItem("Show Message",e -> showMessage())
 					.separator()
 					.menuItem("Exit", e -> System.exit(0))


### PR DESCRIPTION
Added module-info.java and made some small changes, so the library can be used with modularized projects without breaking JLink/JPackage support.

changed source code target to 11
added OpenJFX dependencies