### PR TITLE
Provide an indirect path to the TrayIcon object

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 [![Travis CI Build](https://travis-ci.com/dustinkredmond/FXTrayIcon.svg?branch=main)](https://travis-ci.com/dustinkredmond/FXTrayIcon)
 
 Library for use in JavaFX applications that makes adding a System Tray icon easier.
-The FXTrayIcon class handles all the messy AWT and Swing parts of constructing an icon, 
+The FXTrayIcon class handles all the messy AWT and Swing parts of constructing an icon,
 displaying notifications, creating a context menu, etc. This means that users of FXTrayIcon can
 work solely with its public API and JavaFX classes that they are already familiar with.
 
-Check out the [runnable test application](./src/test/java/com/dustinredmond/fxtrayicon/RunnableTest.java) in the test directory for an example of how this works. 
-
+Check out the [runnable test application](./src/test/java/com/dustinredmond/fxtrayicon/RunnableTest.java) in the test directory for an example of how this works.
 
 ## Usage
 
@@ -23,12 +22,14 @@ icon.show();
 ```
 
 ## Or use Builder Style
+
 ```java
 FXTrayIcon icon = new FXTrayIcon.Builder(stage, iconURL).menuItem("Menu 1", e-> myMethod()).addExitItem().show().build();
 ```
+
 [Click here for a Builder tutorial](https://github.com/dustinkredmond/FXTrayIcon/blob/main/BuilderTutorial.md)
 
-## How do I add to my project 
+## How do I add to my project
 
 The project is available as a Maven dependency on Central. Add the following to POM.xml
 
@@ -57,14 +58,13 @@ You can even use it from a Groovy script!
 *Note, for the current stable version number, use the following:*
 [![Maven Central](https://img.shields.io/maven-central/v/com.dustinredmond.fxtrayicon/FXTrayIcon.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.dustinredmond.fxtrayicon%22%20AND%20a:%22FXTrayIcon%22)
 
-
 ## Features & Screenshots
 
 ### CheckMenuItems
+
 FXTrayIcon now supports the use of CheckMenuItems - See Javadocs for specifics.
 
 ![FXTCheck](./img/FXTCheck.gif)
-
 
 ### FXTrayIcon on Windows 10's tray
 
@@ -72,8 +72,7 @@ FXTrayIcon now supports the use of CheckMenuItems - See Javadocs for specifics.
 
 Above is an example of FXTrayIcon running on Windows 10, of course, you choose your own icon file.
 Here we used a link icon from [Icons8](https://www.icons8.com), they provide thousands of amazing
- icons for developers, both free (with an attribution) and paid.
-
+icons for developers, both free (with an attribution) and paid.
 
 ### Context Menu - uses JavaFX MenuItem
 
@@ -83,54 +82,53 @@ An example of FXTrayIcon's custom context menu, built using JavaFX MenuItems.
 Surprise, surprise, JavaFX MenuItems get translated into AWT MenuItems by FXTrayIcon,
 so there's no need to use those! A developer can work solely with JavaFX Menus and MenuItems.
 
-
 ### Tray notifications
 
 The following can be used to show notifications. Note that the `showMessage()` method
 uses the icon from FXTrayIcon in the notification, while the others use different icons
 to indicate the level of severity of the message.
 
-  - `showMessage(String caption, String content)`
+- `showMessage(String caption, String content)`
     - or `showMessage(String content)`
-      
+
       ![showMessage](./img/showDefault.png)
 
-  - `showInfoMessage(String caption, String content)`
+- `showInfoMessage(String caption, String content)`
     - or `showInfoMessage(String content)`
-      
+
       ![showInfoMessage](./img/showInfo.png)
 
-  - `showWarnMessage(String caption, String content)`
+- `showWarnMessage(String caption, String content)`
     - or `showWarnMessage(String content)`
-      
+
       ![showWarnMessage](./img/showWarn.png)
 
-  - `showErrorMessage(String caption, String content)`
+- `showErrorMessage(String caption, String content)`
     - or `showErrorMessage(String content)`
-      
-      ![showErrorMessage](./img/showError.png)
 
+      ![showErrorMessage](./img/showError.png)
 
 ## Supported operating systems
 
-| OS         | Support Status      | Unsupported Features                                                                                                      |
-|------------|---------------------|---------------------------------------------------------------------------------------------------------------------------|
-| Windows 11 | Fully supported     | N/A                                                                                                                       |
-| Mac OS     | Partially supported | In the `displayMessage()` methods. Custom notification icons are not supported in AppleScript calls, but the TrayIcon is.  |
-| Linux      | Partially supported | Some desktop environments that support `java.awt.SystemTray` are supported. Many are **not**. You should not rely on the `isSupported` method as a matter of truth, testing on individual desktop environments is strongly encouraged.                            |
-
+| OS         | Support Status      | Unsupported Features                                                                                                                                                                                                                   |
+|------------|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Windows 11 | Fully supported     | N/A                                                                                                                                                                                                                                    |
+| Mac OS     | Partially supported | In the `displayMessage()` methods. Custom notification icons are not supported in AppleScript calls, but the TrayIcon is.                                                                                                              |
+| Linux      | Partially supported | Some desktop environments that support `java.awt.SystemTray` are supported. Many are **not**. You should not rely on the `isSupported` method as a matter of truth, testing on individual desktop environments is strongly encouraged. |
 
 Call `FXTrayIcon.isSupported()` to see if the current platform
 supports the system tray.
 
 ### Access to TrayIcon
-Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the underlying TrayIcon awt object, so this can be done in two different ways.
 
-- You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
-- Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
+Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the
+underlying TrayIcon awt object, so this can be done in two different ways.
 
+-   You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
+-   Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
 
 ## Projects using `FXTrayIcon`
+
 - [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.
 - [GlucoStatusFX](https://github.com/HanSolo/glucostatusfx) - Glucose status monitor for Nightscout implemented in JavaFX.
 - [GistFX](https://github.com/RedmondSims/GistFX) - A utility that makes managing and organizing your GitHub Gists easy and convenient.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ supports the system tray.
 ### Access to TrayIcon
 Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the underlying TrayIcon awt object, so this can be done in two different ways.
 
-1) You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
-2) Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
+ 1) You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
+ 2) Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
 
 
 ## Projects using `FXTrayIcon`

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ supports the system tray.
 ### Access to TrayIcon
 Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the underlying TrayIcon awt object, so this can be done in two different ways.
 
-* You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
-* Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
+- You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
+- Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
 
 
 ## Projects using `FXTrayIcon`

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ to indicate the level of severity of the message.
 Call `FXTrayIcon.isSupported()` to see if the current platform
 supports the system tray.
 
+### Access to TrayIcon
+Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the underlying TrayIcon awt object, so this can be done in two different ways.
+
+1) You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
+2) Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
+
 
 ## Projects using `FXTrayIcon`
 - [JDKMon](https://github.com/HanSolo/JDKMon) - A tool that monitors your installed JDK's and informs you about updates.

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ supports the system tray.
 ### Access to TrayIcon
 Being a JavaFX library, much care has gone into keeping the AWT portions of the library out of sight within your IDE while using FXTrayIcon. However, we realize that there are situations where it would be useful to have access to the underlying TrayIcon awt object, so this can be done in two different ways.
 
- 1) You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
- 2) Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
+* You can extend FXTrayIcon and in that extended class, you can access the `getTrayIcon()` protected method.
+* Once you have FXTrayIcon instantiated, you can call the `getRestricted()` method then gain access to the TrayIcon object through that method.
 
 
 ## Projects using `FXTrayIcon`

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -1025,7 +1025,9 @@ public class FXTrayIcon {
                     "Menu Item labels must be unique.");
         }
         if (addExitMenuItem && shown) {
-            this.popupMenu.insert(AWTUtils.convertFromJavaFX(menuItem), this.popupMenu.getItemCount() - 1);
+            int index = this.popupMenu.getItemCount() - 1;
+            index = (index < 0) ? 0 : index;
+            this.popupMenu.insert(AWTUtils.convertFromJavaFX(menuItem), index);
         }
         else {
             this.popupMenu.add(AWTUtils.convertFromJavaFX(menuItem));
@@ -1453,7 +1455,9 @@ public class FXTrayIcon {
             menu.getItems().forEach(subItem ->
                                             awtMenu.add(AWTUtils.convertFromJavaFX(subItem)));
             if(addExitMenuItem && shown) {
-                this.popupMenu.insert(awtMenu, this.popupMenu.getItemCount() - 1);
+                int index = this.popupMenu.getItemCount() - 1;
+                index = (index < 0) ? 0 : index;
+                this.popupMenu.insert(awtMenu, index);
             }
             else {
                 this.popupMenu.add(awtMenu);

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -103,6 +103,13 @@ public class FXTrayIcon {
      */
     private String exitMenuItemLabel = "";
 
+
+    /**
+     * Used for gaining access to AWT components of the library
+     */
+    private final RestrictedInterface restricted;
+
+
     /**
      * Creates a {@code MouseListener} whose
      * single-click action performs the passed
@@ -116,7 +123,6 @@ public class FXTrayIcon {
             public void mouseClicked(MouseEvent me) {
                 Platform.runLater(() -> e.handle(new ActionEvent()));
             }
-
             @Override
             public void mousePressed(MouseEvent ignored) { }
             @Override
@@ -242,8 +248,17 @@ public class FXTrayIcon {
         attemptSetSystemLookAndFeel();
 
         this.parentStage = parentStage;
-        this.trayIcon = new TrayIcon(image, parentStage.getTitle(), popupMenu);
+        this.restricted  = new Restricted(image, parentStage.getTitle(), popupMenu);
+        this.trayIcon    = this.restricted.getTrayIcon();
         this.trayIcon.setImageAutoSize(true);
+    }
+
+    /**
+     * Use this method to gain access to the instantiated awt TrayIcon object
+     */
+    @API
+    public RestrictedInterface getRestricted() {
+        return restricted;
     }
 
     /**
@@ -968,6 +983,21 @@ public class FXTrayIcon {
     @API
     public void addMenuItem(javafx.scene.control.MenuItem menuItem) {
         EventQueue.invokeLater(() -> addMenuItemPrivately(menuItem));
+    }
+
+
+    /**
+     * Adds the ability to add a MenuItem after instantiation without needing to
+     * pass in a MenuItem object.
+     *
+     * @param label - the text on the MenuItem
+     * @param eventHandler - the EventHandler that the MenuItem executes
+     */
+    @API
+    public void addMenuItem(String label, EventHandler<ActionEvent> eventHandler) {
+        javafx.scene.control.MenuItem menuItem = new javafx.scene.control.MenuItem(label);
+        menuItem.setOnAction(eventHandler);
+        addMenuItemPrivately(menuItem);
     }
 
     /**

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -1025,8 +1025,7 @@ public class FXTrayIcon {
                     "Menu Item labels must be unique.");
         }
         if (addExitMenuItem && shown) {
-            int index = this.popupMenu.getItemCount() - 1;
-            index = (index < 0) ? 0 : index;
+            int index = this.popupMenu.getItemCount();
             this.popupMenu.insert(AWTUtils.convertFromJavaFX(menuItem), index);
         }
         else {
@@ -1455,8 +1454,7 @@ public class FXTrayIcon {
             menu.getItems().forEach(subItem ->
                                             awtMenu.add(AWTUtils.convertFromJavaFX(subItem)));
             if(addExitMenuItem && shown) {
-                int index = this.popupMenu.getItemCount() - 1;
-                index = (index < 0) ? 0 : index;
+                int index = this.popupMenu.getItemCount();
                 this.popupMenu.insert(awtMenu, index);
             }
             else {

--- a/src/main/java/com/dustinredmond/fxtrayicon/Restricted.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/Restricted.java
@@ -1,0 +1,54 @@
+package com.dustinredmond.fxtrayicon;
+
+/*
+ * Copyright (c) 2022 Dustin K. Redmond & contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import java.awt.*;
+
+/**
+ * This is a package local class
+ */
+class Restricted implements RestrictedInterface {
+
+	/**
+	 * This is the working instantiation of the TrayIcon object.
+	 * This is the only instantiation that will exist for any
+	 * instantiation of the FXTrayIcon class.
+	 */
+	private final TrayIcon trayIcon;
+
+	/**
+	 * Class Constructor used by FXTrayIcon class
+	 */
+	public Restricted(Image image, String title, PopupMenu popupMenu  ) {
+		this.trayIcon = new TrayIcon(image, title, popupMenu);
+	}
+
+	/**
+	 * public getter for the trayIcon object. This method is only
+	 * obtainable through the getRestricted() method in FXTrayIcon class.
+	 */
+	@Override
+	public TrayIcon getTrayIcon() {
+		return trayIcon;
+	}
+}

--- a/src/main/java/com/dustinredmond/fxtrayicon/RestrictedInterface.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/RestrictedInterface.java
@@ -1,0 +1,8 @@
+package com.dustinredmond.fxtrayicon;
+
+import java.awt.*;
+
+public interface RestrictedInterface {
+
+	public TrayIcon getTrayIcon();
+}


### PR DESCRIPTION
Concerning Issue #72 - I spent some time working with the FXTrayIcon class in an extended subclass to see about using the protected method `getTrayIcon()` and though it can be relatively easy to do when using the base class constructors, it becomes more of a challenge when trying to also use the extended Builder class. Also, having to create a subclass just to gain access to that object seems to me to be a bit inconvenient, though I certainly can understand and appreciate the intent behind declaring that object as protected ... this is a JavaFX library and so all efforts should indeed be made to present it as a full JavaFX library.

So what I came up with will both maintain the existing protection of the object where its not possible to reference it via the protected method AND ALSO provide a relatively convenient way of getting to the object while it remains not exposed directly.

I created a class called `Restricted` that is only local to the package that it's in (so it cannot be accessed nor even seen while using the library), then I put the awt TrayIcon object in that class declaring it as final so that it is only created one time and that is when the final FXTrayIcon class constructor is called and it instantiates the `Restricted` class ... but there's a twist...

The variable named `restricted` is defined as being of type `RestrictedInterface` but when the `Restricted` class is instantiated in the final constructor, it is instantiated and assigned to that variable.

Because the `Restricted` class is only accessible to the package it exists in, the only way to make its `getTrayIcon` public method accessible outside of the package is by having that class implement the interface which has the declaration of that method declared as public - `Restricted` Overrides the interface method.

The result of this is that users of the library can use the `getTrayIcon` method that's inside the package-private `Restricted` class without being able to see or access `Restricted` directly, which preserves the goal of keeping that object protected.

Once FXTrayIcon is instantiated, a developer can gain access to TrayIcon like this:

```
fxtrayIcon.getRestricted().getTrayIcon();
```
It should be noted that the `RestrictedInterface` class is public and therefore it can be seen by users of the library, but there is no code in that class for anyone to use so its exposure poses no threat to any part of anything within the scope of the library.

Here is what this accomplishes:
1) The TrayIcon object remains protected and not DIRECTLY accessible from the instantiated FXTrayIcon class as you originally intended.
2) The class that holds the TrayIcon object cannot be seen by a developer.
3) The TrayIcon object is guaranteed to only be created ONE TIME through the final class constructor of FXTrayIcon.

I believe this is a solution that meets both needs - protecting the object while making it accessible but never "accidentally" accessible ... the dev will have to want to get at it and also know how to do it.

The original behavior of FXTrayIcon has not changed at all so this PR will have no negative impact on existing users.

Java doc comments were added everywhere new code was added.

README was updated to explain the added functionality.

This has been tested and it works.

