### PR TITLE
Added test class for Restricted access

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -103,6 +103,12 @@ public class FXTrayIcon {
      */
     private String exitMenuItemLabel = "";
 
+    /**
+     * This is used to tell the show method to not add the event listener which
+     * normally shows the stage when the icon is clicked. On MacOS, this is
+     * normally activated with a right click.
+     */
+    private boolean noDefaultAction = false;
 
     /**
      * Used for gaining access to AWT components of the library
@@ -290,6 +296,7 @@ public class FXTrayIcon {
         private       ActionListener                              exitMenuItemActionListener;
         private       boolean                                     showTrayIcon       = false;
         private final Image                                       icon;
+        private boolean noDefaultAction = false;
 
 
         /**
@@ -627,6 +634,19 @@ public class FXTrayIcon {
         }
 
         /**
+         * This is used to tell the show method to not add the event listener which
+         * normally shows the stage when the icon is clicked. On MacOS, this is
+         * normally activated with a right click. In order to be able to add a
+         * right click mouse event to the trayIcon object on MacOS, noDefaultAction
+         * needs to be executed.
+         * @return this Builder object
+         */
+        public Builder noDefaultAction() {
+            noDefaultAction = true;
+            return this;
+        }
+
+        /**
          * Sets up Builder so that once FXTrayIcon is instantiated, it will show immediately.
          * @return this Builder object
          */
@@ -659,6 +679,7 @@ public class FXTrayIcon {
         this.addTitleMenuItem = build.addTitleMenuItem;
         this.exitMenuItemLabel = build.exitMenuItemLabel;
         this.exitMenuItemActionListener = build.exitMenuItemActionListener;
+        this.noDefaultAction = build.noDefaultAction;
         if (!build.tooltip.equals("")) setTooltip(build.tooltip);
         if (build.event != null) setOnAction(build.event);
         for (int i = 0; i < BuildOrderUtil.getItemCount(); i++) {
@@ -846,12 +867,27 @@ public class FXTrayIcon {
                 }
 
                 // Show parent stage when user clicks the icon
-                this.trayIcon.addActionListener(stageShowListener);
+                if(!noDefaultAction)
+                    this.trayIcon.addActionListener(stageShowListener);
                 shown = true;
             } catch (AWTException e) {
                 throw new IllegalStateException("Unable to add TrayIcon", e);
             }
         });
+    }
+
+    /**
+     * This is used to tell the show method to not add the event listener which
+     * normally shows the stage when the icon is clicked. On MacOS, this is
+     * normally activated with a right click. In order to be able to add a
+     * right click mouse event to the trayIcon object on MacOS, noDefaultAction
+     * needs to be executed.
+     */
+    public void noDefaultAction() {
+        if(!shown)
+            noDefaultAction = true;
+        else
+            trayIcon.removeActionListener(stageShowListener);
     }
 
 

--- a/src/test/java/com/dustinredmond/fxtrayicon/TestRestrictedAccess.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/TestRestrictedAccess.java
@@ -32,6 +32,11 @@ public class TestRestrictedAccess extends Application {
 		 * event listener, which when clicked, shows the stage.
 		 */
 		icon.getRestricted().getTrayIcon().addMouseListener(new MouseListener() {
+
+			/**
+			 * This event is fired when the mouse is clicked on the tray icon
+			 * @param - MouseEvent
+			 */
 			@Override public void mouseClicked(MouseEvent e) {
 				if(e.getButton() == 3) {
 					Platform.runLater(() -> {
@@ -40,18 +45,34 @@ public class TestRestrictedAccess extends Application {
 				}
 			}
 
+			/**
+			 * Ignored
+			 * @param - MouseEvent
+			 */
 			@Override public void mousePressed(MouseEvent ignored) {
 
 			}
 
+			/**
+			 * Ignored
+			 * @param - MouseEvent
+			 */
 			@Override public void mouseReleased(MouseEvent ignored) {
 
 			}
 
+			/**
+			 * Ignored
+			 * @param - MouseEvent
+			 */
 			@Override public void mouseEntered(MouseEvent ignored) {
 
 			}
 
+			/**
+			 * Ignored
+			 * @param - MouseEvent
+			 */
 			@Override public void mouseExited(MouseEvent ignored) {
 
 			}

--- a/src/test/java/com/dustinredmond/fxtrayicon/TestRestrictedAccess.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/TestRestrictedAccess.java
@@ -1,0 +1,76 @@
+package com.dustinredmond.fxtrayicon;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.net.URL;
+
+public class TestRestrictedAccess extends Application {
+
+	public static void main(String[] args) {
+		launch(args);
+	}
+
+	@Override public void start(Stage primaryStage) throws Exception {
+		createScene(primaryStage);
+		FXTrayIcon icon = new FXTrayIcon.Builder(primaryStage,getIcon(),24,24)
+				.menuItem("This does nothing", e->{})
+				.separator()
+				.addExitMenuItem("Exit")
+				.show()
+				.build();
+
+		/**
+		 * This accesses the restricted trayIcon object and adds a right click
+		 * event listener, which when clicked, shows the stage.
+		 */
+		icon.getRestricted().getTrayIcon().addMouseListener(new MouseListener() {
+			@Override public void mouseClicked(MouseEvent e) {
+				if(e.getButton() == 3) {
+					Platform.runLater(() -> {
+						primaryStage.show();
+					});
+				}
+			}
+
+			@Override public void mousePressed(MouseEvent ignored) {
+
+			}
+
+			@Override public void mouseReleased(MouseEvent ignored) {
+
+			}
+
+			@Override public void mouseEntered(MouseEvent ignored) {
+
+			}
+
+			@Override public void mouseExited(MouseEvent ignored) {
+
+			}
+		});
+	}
+
+	private void createScene(Stage stage) {
+		Label label = new Label("Right clicking works!");
+		label.setPrefSize(150,55);
+		label.setAlignment(Pos.CENTER);
+		VBox box = new VBox(label);
+		scene = new Scene(box);
+		stage.setScene(scene);
+	}
+
+	Scene scene;
+
+	private URL getIcon() {
+		return getClass().getResource("FXIconRedYellow.png");
+	}
+
+}


### PR DESCRIPTION
Also, I added an option to disable the default feature where (on the Mac at least) when you right-click on the icon, it shows the stage. This makes it impossible to add a right-click mouse event listener on trayIcon and then have it do whatever is needed. So by engaging `noDefaultAction()` from the Builder class or from the main class, the desired behavior can be achieved.