### PR TITLE
Animation Error Check Improvements

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/Animation.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/Animation.java
@@ -43,14 +43,15 @@ class Animation {
 
     private Timeline getTimeline() {
         Timeline timeline = new Timeline();
-        KeyFrame keyFrame = new KeyFrame(Duration.millis(frameRateMS), e -> {
-            Image image = imageList.removeFirst();
-            trayIcon.setAnimationFrame(image);
-            imageList.addLast(image);
-        });
-        timeline.getKeyFrames().add(keyFrame);
+        timeline.getKeyFrames().add(new KeyFrame(Duration.millis(frameRateMS), e -> updateImage()));
         timeline.setCycleCount(javafx.animation.Animation.INDEFINITE);
         return timeline;
+    }
+
+    private void updateImage() {
+        Image image = imageList.removeFirst();
+        trayIcon.setAnimationFrame(image);
+        imageList.addLast(image);
     }
 
     Animation(FXTrayIcon trayIcon, LinkedList<Image> imageList, int frameRateMS) {

--- a/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/FXTrayIcon.java
@@ -1806,11 +1806,13 @@ public class FXTrayIcon {
      */
     @API
     public void newAnimation(LinkedList<javafx.scene.image.Image> imageList, int frameRateMS) {
-        LinkedList<Image> list = new LinkedList<>();
-        for (javafx.scene.image.Image fxImage : imageList) {
-            list.addLast(loadImageFromFX(fxImage, iconScale.width(), iconScale.height()));
+        if(imageList != null && frameRateMS > 0){
+            LinkedList<Image> list = new LinkedList<>();
+            for (javafx.scene.image.Image fxImage : imageList) {
+                list.addLast(loadImageFromFX(fxImage, iconScale.width(), iconScale.height()));
+            }
+            animation = new Animation(this, list, frameRateMS);
         }
-        animation = new Animation(this, list, frameRateMS);
     }
 
     /**
@@ -1830,13 +1832,15 @@ public class FXTrayIcon {
      */
     @API
     public void newAnimation(LinkedList<File> imageFileList, int frameRateMS, boolean sortList) {
-        if (sortList)
-            imageFileList.sort(Comparator.comparing(File::getName));
-        LinkedList<Image> imageList = new LinkedList<>();
-        for (File file : imageFileList) {
-            imageList.addLast(loadImageFromFile(file, iconScale.width(), iconScale.height()));
+        if(imageFileList != null && frameRateMS > 0) {
+            if (sortList)
+                imageFileList.sort(Comparator.comparing(File::getName));
+            LinkedList<Image> imageList = new LinkedList<>();
+            for (File file : imageFileList) {
+                imageList.addLast(loadImageFromFile(file, iconScale.width(), iconScale.height()));
+            }
+            animation = new Animation(this, imageList, frameRateMS);
         }
-        animation = new Animation(this, imageList, frameRateMS);
     }
 
     /**
@@ -1844,7 +1848,7 @@ public class FXTrayIcon {
      */
     @API
     public void play() {
-        if (animation != null) {
+        if (animation != null &&(isStopped() || isPaused())) {
             animation.play();
         }
     }
@@ -1854,8 +1858,8 @@ public class FXTrayIcon {
      */
     @API
     public void stop() {
-        if (animation != null && isRunning()) {
-                animation.stop();
+        if (animation != null && (isRunning() || isPaused())) {
+            animation.stop();
         }
     }
 
@@ -1895,7 +1899,9 @@ public class FXTrayIcon {
      */
     @API
     protected void setAnimationFrame(Image frame) {
-        this.trayIcon.setImage(frame);
+        if(frame != null && this.trayIcon != null) {
+            this.trayIcon.setImage(frame);
+        }
     }
 
     /**
@@ -1916,11 +1922,13 @@ public class FXTrayIcon {
      */
     @API
     public void pauseResume() {
-        if (animation != null && isRunning()) {
-            pause();
-        }
-        else if (isPaused()) {
-            play();
+        if(animation != null) {
+            if (isRunning()) {
+                pause();
+            }
+            else if (isPaused()) {
+                play();
+            }
         }
     }
 
@@ -1961,7 +1969,7 @@ public class FXTrayIcon {
      */
     @API
     public boolean isStopped() {
-        return animation == null ? false : animation.isStopped();
+        return animation == null ? true : animation.isStopped();
     }
 
     /**
@@ -1970,7 +1978,7 @@ public class FXTrayIcon {
      */
     @API
     public Timeline getAnimationTimeline() {
-        return animation.timeline();
+        return animation == null ? null : animation.timeline();
     }
 
 
@@ -1996,5 +2004,4 @@ public class FXTrayIcon {
     public void setIconSize(int sizeWH) {
         iconScale = new IconScale(sizeWH, sizeWH);
     }
-
 }

--- a/src/test/java/com/dustinredmond/fxtrayicon/animation/Animation.java
+++ b/src/test/java/com/dustinredmond/fxtrayicon/animation/Animation.java
@@ -7,11 +7,13 @@ import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
+import javafx.scene.image.Image;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedList;
 
@@ -33,11 +35,33 @@ public class Animation extends Application {
     private LinkedList<File> animationFiles(int max, String folder) {
         LinkedList<File> fileImages = new LinkedList<>();
         for (int x = 1; x <= max; x++) {
-            String fileNumber = (x < 10) ? "0" + x : String.valueOf(x);
-            File file = getResourceFile(String.format(filePath, folder, fileNumber));
-            fileImages.addLast(file);
+            try {
+                String fileNumber = (x < 10) ? "0" + x : String.valueOf(x);
+                File file = getResourceFile(String.format(filePath, folder, fileNumber));
+                Image image = new Image(file.toURI().toURL().toString());
+                fileImages.addLast(file);
+            }
+            catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
         }
         return fileImages;
+    }
+
+    private LinkedList<Image> animationImages(int max, String folder) {
+        LinkedList<Image> fxImages = new LinkedList<>();
+        for (int x = 1; x <= max; x++) {
+            try {
+                String fileNumber = (x < 10) ? "0" + x : String.valueOf(x);
+                File file = getResourceFile(String.format(filePath, folder, fileNumber));
+                Image image = new Image(file.toURI().toURL().toString());
+                fxImages.addLast(image);
+            }
+            catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return fxImages;
     }
 
     @Override
@@ -87,39 +111,39 @@ public class Animation extends Application {
 
     private void startOne() {
         File icon = getResourceFile(String.format(iconPath, "One"));
-        LinkedList<File> fileList = animationFiles(48, "One");
+        LinkedList<Image> fileList = animationImages(48, "One");
         if (fxTrayIcon == null) {
             startTrayIcon(fileList, icon, 100);
         }
         else {
             fxTrayIcon.stop();
-            fxTrayIcon.newAnimation(fileList, 100, false);
+            fxTrayIcon.newAnimation(fileList, 100);
             fxTrayIcon.setGraphic(icon, 24, 24);
         }
     }
 
     private void startTwo() {
         File icon = getResourceFile(String.format(iconPath, "Two"));
-        LinkedList<File> fileList = animationFiles(48, "Two");
+        LinkedList<Image> fileList = animationImages(48, "Two");
         if (fxTrayIcon == null) {
             startTrayIcon(fileList, icon, 100);
         }
         else {
             fxTrayIcon.stop();
-            fxTrayIcon.newAnimation(fileList, 100, false);
+            fxTrayIcon.newAnimation(fileList, 100);
             fxTrayIcon.setGraphic(icon, 24, 24);
         }
     }
 
     private void startThree() {
         File icon = getResourceFile(String.format(iconPath, "Three"));
-        LinkedList<File> fileList = animationFiles(41, "Three");
+        LinkedList<Image> fileList = animationImages(41, "Three");
         if (fxTrayIcon == null) {
             startTrayIcon(fileList, icon, 150);
         }
         else {
             fxTrayIcon.stop();
-            fxTrayIcon.newAnimation(fileList, 150, false);
+            fxTrayIcon.newAnimation(fileList, 150);
             if (icon.exists())
                 fxTrayIcon.setGraphic(icon, 24, 24);
             else {
@@ -129,9 +153,20 @@ public class Animation extends Application {
     }
 
 
-    private void startTrayIcon(LinkedList<File> fileList, File icon, int frameRate) {
+    private void startTrayIcon(LinkedList<File> fileList, File icon, int frameRate, boolean sortList) {
         fxTrayIcon = new FXTrayIcon.Builder(primaryStage, icon)
-                .animate(fileList, frameRate, false)
+                .animate(fileList, frameRate, sortList)
+                .menuItem("Start", e -> startAnimation())
+                .menuItem("Stop", e -> stopAnimation())
+                .separator()
+                .addExitMenuItem()
+                .show()
+                .build();
+    }
+
+    private void startTrayIcon(LinkedList<Image> imageList, File icon, int frameRate) {
+        fxTrayIcon = new FXTrayIcon.Builder(primaryStage, icon)
+                .animate(imageList, frameRate)
                 .menuItem("Start", e -> startAnimation())
                 .menuItem("Stop", e -> stopAnimation())
                 .separator()


### PR DESCRIPTION
I was getting some errors deep in the java.awt classes from the `setAnimationFrame(Image frame)` method, so I added null checks to that method and beefed up the null checks in all animation-related methods. I stopped getting the errors after the added checks.
