### PR TITLE
Update disable property correctly + Github Workflow CI Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: CI build
+
+on: [push]
+
+jobs:
+  builds:
+    name: '${{ matrix.os }} with Java ${{ matrix.jdk }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        jdk: [17,21]
+        os: [windows-latest, ubuntu-latest]
+      fail-fast: false
+      max-parallel: 6
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Java ${{ matrix.jdk }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.jdk }}
+      - name: Compile
+        run: |
+          mvn clean package

--- a/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
@@ -91,6 +91,8 @@ class AWTUtils {
         // Disable the MenuItem if the FX item is disabled
         awtItem.setEnabled(!fxItem.isDisable());
 
+        fxItem.disabledProperty().addListener(e -> { awItem.setEnabled(!fxItem.isDiable())});
+
         fxItem.textProperty().addListener(e -> { awtItem.setLabel(fxItem.getText());});
 
         return awtItem;

--- a/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
@@ -91,9 +91,9 @@ class AWTUtils {
         // Disable the MenuItem if the FX item is disabled
         awtItem.setEnabled(!fxItem.isDisable());
 
-        fxItem.disabledProperty().addListener(e -> { awItem.setEnabled(!fxItem.isDiable())});
+        fxItem.disableProperty().addListener(e -> awtItem.setEnabled(!fxItem.isDisable()));
 
-        fxItem.textProperty().addListener(e -> { awtItem.setLabel(fxItem.getText());});
+        fxItem.textProperty().addListener(e -> awtItem.setLabel(fxItem.getText()));
 
         return awtItem;
     }


### PR DESCRIPTION
@dustinkredmond
Small bugfix.

The Disable Property of the FXMenu is now bound to the enabled property of the AWTMenu.
I tested it, and i can. confirm that it works now properly!

I've also added a github actions CI build.
So you (and I) can see, that my change compiles properly!

Let me now, whether you need anything from my PR.