### PR TITLE
Implemented bug fix for Issue #65

### DIFF
--- a/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
+++ b/src/main/java/com/dustinredmond/fxtrayicon/AWTUtils.java
@@ -46,8 +46,11 @@ class AWTUtils {
             CheckboxMenuItem checkboxMenuItem = new CheckboxMenuItem(menuItemText);
             checkboxMenuItem.setState(((CheckMenuItem) fxItem).isSelected());
             if (fxItem.getOnAction() != null) {
-                checkboxMenuItem.addItemListener(e -> Platform
-                        .runLater(() -> fxItem.getOnAction().handle(new ActionEvent())));
+                checkboxMenuItem.addItemListener(e -> Platform.runLater(() -> {
+                    CheckMenuItem fxCheck = (CheckMenuItem) fxItem;
+                    fxCheck.setSelected(checkboxMenuItem.getState()); // sync AWT -> FX
+                    fxCheck.getOnAction().handle(new ActionEvent()); // trigger FX handler
+                }));
             }
             awtItem = checkboxMenuItem;
             ((CheckMenuItem) fxItem).selectedProperty().addListener(e -> ((CheckboxMenuItem) awtItem).setState(((CheckMenuItem) fxItem).isSelected()));


### PR DESCRIPTION
Updated the AWTUtils class / convertFromJavaFX method so that CheckMenuItems have their update events properly triggered when the user changes the state.

Using the code posted in Issue #65 I tested the code using the 4.2.2 version of the library without the users added fix and the state would always report false. When I tested the same code with this bug fix, the state properly reports true or false depending on the state of the check menu item.

This code change fixes the problem.